### PR TITLE
added requestParams option

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -2,10 +2,11 @@ import { RemoteInstance as Directus } from 'directus-sdk-javascript';
 import Colors from 'colors';
 
 export default class DirectusFetcher {
-    constructor(apiKey, url, version) {
+    constructor(apiKey, url, version, requestParams) {
         this.apiKey = apiKey;
         this.url = url;
         this.version = version;
+        this.requestParams = requestParams;
         // Initialize client
         this.client = new Directus({
             url: this.url,
@@ -35,7 +36,7 @@ export default class DirectusFetcher {
     }
 
     async getAllItemsForTable(name) {
-        const records = await this.client.getItems(name);
+        const records = await this.client.getItems(name, this.requestParams);
         return records.data;
     }
 }

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -5,13 +5,17 @@ import Colors from 'colors';
 let _url = '';
 let _apiKey = '';
 let _version = '1.1';
+let _requestParams = {
+    depth: 1,
+}
 
 exports.sourceNodes = async ({ boundActionCreators }, {
     url,
     protocol,
     apiKey,
     version,
-    nameExceptions
+    nameExceptions,
+    requestParams,
 }) => {
     const { createNode } = boundActionCreators;
 
@@ -30,8 +34,11 @@ exports.sourceNodes = async ({ boundActionCreators }, {
     // Assign the API key
     _apiKey = apiKey;
 
+    // Set request parameters
+    _requestParams = requestParams || _requestParams;
+
     // Initialize the Fetcher class with API key and URL
-    const fetcher = new Fetcher(_apiKey, _url, _version);
+    const fetcher = new Fetcher(_apiKey, _url, _version, _requestParams);
 
     console.log(`gatsby-source-directus`.cyan, 'Fetching Directus tables data...');
 


### PR DESCRIPTION
The depth parameter for fetching table items is set to 1 by default by directus-sdk-javascript. When using relational tables, the fetch depth has to be modifiable to get useful data for use in the context of rendering static pages.

This minor update allows for setting a requestParams via the plugin's options.