### PR TITLE
rename boundActionCreators for Gatsby v3

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -1,0 +1,190 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+require('babel-polyfill');
+
+var _directusSdkJavascript = require('directus-sdk-javascript');
+
+var _colors = require('colors');
+
+var _colors2 = _interopRequireDefault(_colors);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var DirectusFetcher = function () {
+    function DirectusFetcher(apiKey, url, version, requestParams, fileRequestParams) {
+        _classCallCheck(this, DirectusFetcher);
+
+        this.apiKey = apiKey;
+        this.url = url;
+        this.version = version;
+        this.requestParams = requestParams;
+        this.fileRequestParams = fileRequestParams;
+        // Initialize client
+        this.client = new _directusSdkJavascript.RemoteInstance({
+            url: this.url,
+            accessToken: this.apiKey
+        });
+    }
+
+    _createClass(DirectusFetcher, [{
+        key: 'getAllTablesData',
+        value: function () {
+            var _ref = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee2() {
+                var _this = this;
+
+                var tablesData, data;
+                return regeneratorRuntime.wrap(function _callee2$(_context2) {
+                    while (1) {
+                        switch (_context2.prev = _context2.next) {
+                            case 0:
+                                _context2.next = 2;
+                                return this.client.getTables({});
+
+                            case 2:
+                                tablesData = _context2.sent;
+
+                                if (!(tablesData.data === undefined)) {
+                                    _context2.next = 6;
+                                    break;
+                                }
+
+                                console.error('\ngatsby-source-directus'.blue, 'error'.red, 'gatsby-source-directus: An error occurred while fetching the table list.', tablesData);
+                                return _context2.abrupt('return');
+
+                            case 6:
+                                data = [];
+
+                                // Get details for all the tables
+
+                                _context2.next = 9;
+                                return Promise.all(tablesData.data.map(function () {
+                                    var _ref2 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(obj) {
+                                        var tableData;
+                                        return regeneratorRuntime.wrap(function _callee$(_context) {
+                                            while (1) {
+                                                switch (_context.prev = _context.next) {
+                                                    case 0:
+                                                        _context.next = 2;
+                                                        return _this.client.getTable(obj.name);
+
+                                                    case 2:
+                                                        tableData = _context.sent;
+
+                                                        data.push(tableData.data);
+
+                                                    case 4:
+                                                    case 'end':
+                                                        return _context.stop();
+                                                }
+                                            }
+                                        }, _callee, _this);
+                                    }));
+
+                                    return function (_x) {
+                                        return _ref2.apply(this, arguments);
+                                    };
+                                }()));
+
+                            case 9:
+                                return _context2.abrupt('return', data);
+
+                            case 10:
+                            case 'end':
+                                return _context2.stop();
+                        }
+                    }
+                }, _callee2, this);
+            }));
+
+            function getAllTablesData() {
+                return _ref.apply(this, arguments);
+            }
+
+            return getAllTablesData;
+        }()
+    }, {
+        key: 'getAllFiles',
+        value: function () {
+            var _ref3 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee3() {
+                var filesData;
+                return regeneratorRuntime.wrap(function _callee3$(_context3) {
+                    while (1) {
+                        switch (_context3.prev = _context3.next) {
+                            case 0:
+                                _context3.next = 2;
+                                return this.client.getFiles(this.fileRequestParams);
+
+                            case 2:
+                                filesData = _context3.sent;
+
+                                if (!(filesData.data === undefined)) {
+                                    _context3.next = 6;
+                                    break;
+                                }
+
+                                console.error('\ngatsby-source-directus'.blue, 'error'.red, 'gatsby-source-directus: An error occurred while fetching the files.', filesData);
+                                return _context3.abrupt('return');
+
+                            case 6:
+                                return _context3.abrupt('return', filesData.data);
+
+                            case 7:
+                            case 'end':
+                                return _context3.stop();
+                        }
+                    }
+                }, _callee3, this);
+            }));
+
+            function getAllFiles() {
+                return _ref3.apply(this, arguments);
+            }
+
+            return getAllFiles;
+        }()
+    }, {
+        key: 'getAllItemsForTable',
+        value: function () {
+            var _ref4 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee4(name) {
+                var records;
+                return regeneratorRuntime.wrap(function _callee4$(_context4) {
+                    while (1) {
+                        switch (_context4.prev = _context4.next) {
+                            case 0:
+                                _context4.next = 2;
+                                return this.client.getItems(name, this.requestParams);
+
+                            case 2:
+                                records = _context4.sent;
+                                return _context4.abrupt('return', records.data);
+
+                            case 4:
+                            case 'end':
+                                return _context4.stop();
+                        }
+                    }
+                }, _callee4, this);
+            }));
+
+            function getAllItemsForTable(_x2) {
+                return _ref4.apply(this, arguments);
+            }
+
+            return getAllItemsForTable;
+        }()
+    }]);
+
+    return DirectusFetcher;
+}();
+
+exports.default = DirectusFetcher;

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,0 +1,379 @@
+'use strict';
+
+var _fetch = require('./fetch');
+
+var _fetch2 = _interopRequireDefault(_fetch);
+
+var _process = require('./process');
+
+var _colors = require('colors');
+
+var _colors2 = _interopRequireDefault(_colors);
+
+var _gatsbySourceFilesystem = require('gatsby-source-filesystem');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, arguments); return new Promise(function (resolve, reject) { function step(key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { return Promise.resolve(value).then(function (value) { step("next", value); }, function (err) { step("throw", err); }); } } return step("next"); }); }; }
+
+var _url = '';
+var _apiKey = '';
+var _version = '1.1';
+var _requestParams = {
+    depth: 1
+};
+var _fileRequestParams = {};
+var _auth = {};
+
+exports.sourceNodes = function () {
+    var _ref3 = _asyncToGenerator( /*#__PURE__*/regeneratorRuntime.mark(function _callee(_ref, _ref2) {
+        var actions = _ref.actions,
+            getNode = _ref.getNode,
+            store = _ref.store,
+            cache = _ref.cache,
+            createNodeId = _ref.createNodeId;
+        var url = _ref2.url,
+            protocol = _ref2.protocol,
+            apiKey = _ref2.apiKey,
+            version = _ref2.version,
+            nameExceptions = _ref2.nameExceptions,
+            requestParams = _ref2.requestParams,
+            fileRequestParams = _ref2.fileRequestParams,
+            auth = _ref2.auth;
+
+        var createNode, fetcher, allFilesData, filesDownloaded, allFiles, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, fileData, fileNode, localFileNode, allTablesData, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, tableData, tableNode, tableItems, name, ItemNode, _iteratorNormalCompletion3, _didIteratorError3, _iteratorError3, _iterator3, _step3, tableItemData, tableItemNode;
+
+        return regeneratorRuntime.wrap(function _callee$(_context) {
+            while (1) {
+                switch (_context.prev = _context.next) {
+                    case 0:
+                        createNode = actions.createNode;
+
+
+                        protocol = protocol !== undefined && protocol !== '' ? protocol : 'http';
+                        protocol = protocol + "://";
+
+                        // Trim any trailing slashes from the URL
+                        url = url.replace(/\/$/, "");
+
+                        // Assign the version
+                        _version = version !== undefined && version !== '' ? version : _version;
+
+                        // Merge the URL with a protocol
+                        _url = protocol + url + ('/api/' + _version + '/');
+
+                        // Assign the API key
+                        _apiKey = apiKey;
+
+                        // Set request parameters
+                        _requestParams = requestParams || _requestParams;
+
+                        // Set parameters for file fetching
+                        _fileRequestParams = fileRequestParams || _fileRequestParams;
+
+                        // Set htaccess auth for file download
+                        _auth = auth || _auth;
+
+                        // Initialize the Fetcher class with API key and URL
+                        fetcher = new _fetch2.default(_apiKey, _url, _version, _requestParams, _fileRequestParams);
+
+
+                        console.log('gatsby-source-directus'.cyan, 'Fetching Directus files data...');
+
+                        _context.next = 14;
+                        return fetcher.getAllFiles();
+
+                    case 14:
+                        allFilesData = _context.sent;
+
+
+                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Fetched', allFilesData.length.toString().yellow, 'files from Directus.');
+                        console.log('gatsby-source-directus'.cyan, 'Downloading Directus files...');
+
+                        filesDownloaded = 0, allFiles = [];
+                        _iteratorNormalCompletion = true;
+                        _didIteratorError = false;
+                        _iteratorError = undefined;
+                        _context.prev = 21;
+                        _iterator = allFilesData[Symbol.iterator]();
+
+                    case 23:
+                        if (_iteratorNormalCompletion = (_step = _iterator.next()).done) {
+                            _context.next = 42;
+                            break;
+                        }
+
+                        fileData = _step.value;
+                        fileNode = (0, _process.FileNode)(fileData);
+                        localFileNode = void 0;
+                        _context.prev = 27;
+                        _context.next = 30;
+                        return (0, _gatsbySourceFilesystem.createRemoteFileNode)({
+                            url: encodeURI('https:' + fileNode.url),
+                            store: store,
+                            cache: cache,
+                            createNode: createNode,
+                            createNodeId: createNodeId,
+                            auth: _auth
+                        });
+
+                    case 30:
+                        localFileNode = _context.sent;
+                        _context.next = 36;
+                        break;
+
+                    case 33:
+                        _context.prev = 33;
+                        _context.t0 = _context['catch'](27);
+
+                        console.error('\ngatsby-source-directus'.blue, 'error'.red, 'gatsby-source-directus: An error occurred while downloading the files.', _context.t0);
+
+                    case 36:
+
+                        if (localFileNode) {
+                            filesDownloaded++;
+                            fileNode.localFile___NODE = localFileNode.id;
+
+                            // When `gatsby-source-filesystem` creates the file nodes, all reference
+                            // to the original data source is wiped out. This object links the
+                            // directus reference (that's used by other objects to reference files)
+                            // to the gatsby reference (that's accessible in GraphQL queries). Then,
+                            // when each table row is created (in ./process.js), if a file is on a row
+                            // we find it in this array and put the Gatsby URL on the directus node.
+                            //
+                            // This is a hacky solution, but it does the trick for very basic raw file capture
+                            // TODO see if we can implement gatsby-transformer-sharp style queries
+                            allFiles.push({
+                                directus: fileNode,
+                                gatsby: localFileNode
+                            });
+                        }
+
+                        _context.next = 39;
+                        return createNode(fileNode);
+
+                    case 39:
+                        _iteratorNormalCompletion = true;
+                        _context.next = 23;
+                        break;
+
+                    case 42:
+                        _context.next = 48;
+                        break;
+
+                    case 44:
+                        _context.prev = 44;
+                        _context.t1 = _context['catch'](21);
+                        _didIteratorError = true;
+                        _iteratorError = _context.t1;
+
+                    case 48:
+                        _context.prev = 48;
+                        _context.prev = 49;
+
+                        if (!_iteratorNormalCompletion && _iterator.return) {
+                            _iterator.return();
+                        }
+
+                    case 51:
+                        _context.prev = 51;
+
+                        if (!_didIteratorError) {
+                            _context.next = 54;
+                            break;
+                        }
+
+                        throw _iteratorError;
+
+                    case 54:
+                        return _context.finish(51);
+
+                    case 55:
+                        return _context.finish(48);
+
+                    case 56:
+
+                        if (filesDownloaded === allFilesData.length) {
+                            console.log('gatsby-source-directus'.blue, 'success'.green, 'Downloaded all', filesDownloaded.toString().yellow, 'files from Directus.');
+                        } else {
+                            console.log('gatsby-source-directus'.blue, 'warning'.yellow, 'skipped', (filesDownloaded - allFilesData.length).toString().yellow, 'files from downloading');
+                        }
+
+                        console.log('gatsby-source-directus'.cyan, 'Fetching Directus tables data...');
+
+                        // Fetch all the tables with data from Directus in a raw format
+                        _context.next = 60;
+                        return fetcher.getAllTablesData();
+
+                    case 60:
+                        allTablesData = _context.sent;
+
+
+                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Fetched', allTablesData.length.toString().yellow, 'tables from Directus.');
+
+                        _iteratorNormalCompletion2 = true;
+                        _didIteratorError2 = false;
+                        _iteratorError2 = undefined;
+                        _context.prev = 65;
+                        _iterator2 = allTablesData[Symbol.iterator]();
+
+                    case 67:
+                        if (_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done) {
+                            _context.next = 114;
+                            break;
+                        }
+
+                        tableData = _step2.value;
+                        tableNode = (0, _process.TableNode)(tableData);
+                        _context.next = 72;
+                        return createNode(tableNode);
+
+                    case 72:
+                        _context.next = 74;
+                        return fetcher.getAllItemsForTable(tableData.name);
+
+                    case 74:
+                        tableItems = _context.sent;
+
+                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Fetched', tableItems.length.toString().cyan, 'items for ', tableData.name.cyan, ' table...');
+
+                        // Get the name for this node type
+                        name = (0, _process.getNodeTypeNameForTable)(tableData.name, nameExceptions);
+
+                        console.log('gatsby-source-directus'.blue, 'info'.cyan, 'Generating Directus' + name + ' node type...');
+
+                        // We're creating a separate Item Type for every table
+                        ItemNode = (0, _process.createTableItemFactory)(name, allFiles);
+
+                        if (!(tableItems && tableItems.length > 0)) {
+                            _context.next = 110;
+                            break;
+                        }
+
+                        // Get all the items for the table above and create a gatsby node for it
+                        _iteratorNormalCompletion3 = true;
+                        _didIteratorError3 = false;
+                        _iteratorError3 = undefined;
+                        _context.prev = 83;
+                        _iterator3 = tableItems[Symbol.iterator]();
+
+                    case 85:
+                        if (_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done) {
+                            _context.next = 93;
+                            break;
+                        }
+
+                        tableItemData = _step3.value;
+
+                        // Create a Table Item node based on the API response
+                        tableItemNode = ItemNode(tableItemData, {
+                            parent: tableNode.id
+                        });
+
+                        // Pass it to Gatsby to create a node
+
+                        _context.next = 90;
+                        return createNode(tableItemNode);
+
+                    case 90:
+                        _iteratorNormalCompletion3 = true;
+                        _context.next = 85;
+                        break;
+
+                    case 93:
+                        _context.next = 99;
+                        break;
+
+                    case 95:
+                        _context.prev = 95;
+                        _context.t2 = _context['catch'](83);
+                        _didIteratorError3 = true;
+                        _iteratorError3 = _context.t2;
+
+                    case 99:
+                        _context.prev = 99;
+                        _context.prev = 100;
+
+                        if (!_iteratorNormalCompletion3 && _iterator3.return) {
+                            _iterator3.return();
+                        }
+
+                    case 102:
+                        _context.prev = 102;
+
+                        if (!_didIteratorError3) {
+                            _context.next = 105;
+                            break;
+                        }
+
+                        throw _iteratorError3;
+
+                    case 105:
+                        return _context.finish(102);
+
+                    case 106:
+                        return _context.finish(99);
+
+                    case 107:
+                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Directus' + name + ' node generated');
+                        _context.next = 111;
+                        break;
+
+                    case 110:
+                        console.log('gatsby-source-directus'.blue, 'warning'.yellow, tableData.name + ' table has no rows. Skipping...');
+
+                    case 111:
+                        _iteratorNormalCompletion2 = true;
+                        _context.next = 67;
+                        break;
+
+                    case 114:
+                        _context.next = 120;
+                        break;
+
+                    case 116:
+                        _context.prev = 116;
+                        _context.t3 = _context['catch'](65);
+                        _didIteratorError2 = true;
+                        _iteratorError2 = _context.t3;
+
+                    case 120:
+                        _context.prev = 120;
+                        _context.prev = 121;
+
+                        if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                            _iterator2.return();
+                        }
+
+                    case 123:
+                        _context.prev = 123;
+
+                        if (!_didIteratorError2) {
+                            _context.next = 126;
+                            break;
+                        }
+
+                        throw _iteratorError2;
+
+                    case 126:
+                        return _context.finish(123);
+
+                    case 127:
+                        return _context.finish(120);
+
+                    case 128:
+
+                        console.log("AFTER");
+
+                    case 129:
+                    case 'end':
+                        return _context.stop();
+                }
+            }
+        }, _callee, undefined, [[21, 44, 48, 56], [27, 33], [49,, 51, 55], [65, 116, 120, 128], [83, 95, 99, 107], [100,, 102, 106], [121,, 123, 127]]);
+    }));
+
+    return function (_x, _x2) {
+        return _ref3.apply(this, arguments);
+    };
+}();

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -41,7 +41,7 @@ exports.sourceNodes = function () {
             fileRequestParams = _ref2.fileRequestParams,
             auth = _ref2.auth;
 
-        var createNode, fetcher, allTablesData, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, tableData, tableNode, tableItems, name, ItemNode, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, tableItemData, tableItemNode;
+        var createNode, fetcher, allFilesData, filesDownloaded, allFiles, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, fileData, fileNode, localFileNode, allTablesData, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, tableData, tableNode, tableItems, name, ItemNode, _iteratorNormalCompletion3, _didIteratorError3, _iteratorError3, _iterator3, _step3, tableItemData, tableItemNode;
 
         return regeneratorRuntime.wrap(function _callee$(_context) {
             while (1) {
@@ -77,88 +77,162 @@ exports.sourceNodes = function () {
                         // Initialize the Fetcher class with API key and URL
                         fetcher = new _fetch2.default(_apiKey, _url, _version, _requestParams, _fileRequestParams);
 
-                        /*
-                        console.log(`gatsby-source-directus`.cyan, 'Fetching Directus files data...');
-                         const allFilesData = await fetcher.getAllFiles();
-                         console.log(`gatsby-source-directus`.blue, 'success'.green, `Fetched`, allFilesData.length.toString().yellow, `files from Directus.`);
-                        console.log(`gatsby-source-directus`.cyan, 'Downloading Directus files...');
-                         let filesDownloaded = 0,
-                            allFiles = [];
-                         for (let fileData of allFilesData) {
-                            const fileNode = FileNode(fileData);
-                            let localFileNode
-                             try {
-                                localFileNode = await createRemoteFileNode({
-                                url: encodeURI(`https:${fileNode.url}`),
-                                store,
-                                cache,
-                                createNode,
-                                createNodeId,
-                                auth: _auth,
-                                })
-                            } catch (e) {
-                                console.error(`\ngatsby-source-directus`.blue, 'error'.red, `gatsby-source-directus: An error occurred while downloading the files.`, e);
-                            }
-                             if (localFileNode) {
-                                filesDownloaded++;
-                                fileNode.localFile___NODE = localFileNode.id;
-                                 // When `gatsby-source-filesystem` creates the file nodes, all reference
-                                // to the original data source is wiped out. This object links the
-                                // directus reference (that's used by other objects to reference files)
-                                // to the gatsby reference (that's accessible in GraphQL queries). Then,
-                                // when each table row is created (in ./process.js), if a file is on a row
-                                // we find it in this array and put the Gatsby URL on the directus node.
-                                //
-                                // This is a hacky solution, but it does the trick for very basic raw file capture
-                                // TODO see if we can implement gatsby-transformer-sharp style queries
-                                allFiles.push({
-                                    directus: fileNode,
-                                    gatsby: localFileNode
-                                });
-                            }
-                             await createNode(fileNode);
+
+                        console.log('gatsby-source-directus'.cyan, 'Fetching Directus files data...');
+
+                        _context.next = 14;
+                        return fetcher.getAllFiles();
+
+                    case 14:
+                        allFilesData = _context.sent;
+
+
+                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Fetched', allFilesData.length.toString().yellow, 'files from Directus.');
+                        console.log('gatsby-source-directus'.cyan, 'Downloading Directus files...');
+
+                        filesDownloaded = 0, allFiles = [];
+                        _iteratorNormalCompletion = true;
+                        _didIteratorError = false;
+                        _iteratorError = undefined;
+                        _context.prev = 21;
+                        _iterator = allFilesData[Symbol.iterator]();
+
+                    case 23:
+                        if (_iteratorNormalCompletion = (_step = _iterator.next()).done) {
+                            _context.next = 42;
+                            break;
                         }
-                         if (filesDownloaded === allFilesData.length) {
-                            console.log(`gatsby-source-directus`.blue, 'success'.green, `Downloaded all`, filesDownloaded.toString().yellow, `files from Directus.`);
+
+                        fileData = _step.value;
+                        fileNode = (0, _process.FileNode)(fileData);
+                        localFileNode = void 0;
+                        _context.prev = 27;
+                        _context.next = 30;
+                        return (0, _gatsbySourceFilesystem.createRemoteFileNode)({
+                            url: encodeURI('https:' + fileNode.url),
+                            store: store,
+                            cache: cache,
+                            createNode: createNode,
+                            createNodeId: createNodeId,
+                            auth: _auth
+                        });
+
+                    case 30:
+                        localFileNode = _context.sent;
+                        _context.next = 36;
+                        break;
+
+                    case 33:
+                        _context.prev = 33;
+                        _context.t0 = _context['catch'](27);
+
+                        console.error('\ngatsby-source-directus'.blue, 'error'.red, 'gatsby-source-directus: An error occurred while downloading the files.', _context.t0);
+
+                    case 36:
+
+                        if (localFileNode) {
+                            filesDownloaded++;
+                            fileNode.localFile___NODE = localFileNode.id;
+
+                            // When `gatsby-source-filesystem` creates the file nodes, all reference
+                            // to the original data source is wiped out. This object links the
+                            // directus reference (that's used by other objects to reference files)
+                            // to the gatsby reference (that's accessible in GraphQL queries). Then,
+                            // when each table row is created (in ./process.js), if a file is on a row
+                            // we find it in this array and put the Gatsby URL on the directus node.
+                            //
+                            // This is a hacky solution, but it does the trick for very basic raw file capture
+                            // TODO see if we can implement gatsby-transformer-sharp style queries
+                            allFiles.push({
+                                directus: fileNode,
+                                gatsby: localFileNode
+                            });
+                        }
+
+                        _context.next = 39;
+                        return createNode(fileNode);
+
+                    case 39:
+                        _iteratorNormalCompletion = true;
+                        _context.next = 23;
+                        break;
+
+                    case 42:
+                        _context.next = 48;
+                        break;
+
+                    case 44:
+                        _context.prev = 44;
+                        _context.t1 = _context['catch'](21);
+                        _didIteratorError = true;
+                        _iteratorError = _context.t1;
+
+                    case 48:
+                        _context.prev = 48;
+                        _context.prev = 49;
+
+                        if (!_iteratorNormalCompletion && _iterator.return) {
+                            _iterator.return();
+                        }
+
+                    case 51:
+                        _context.prev = 51;
+
+                        if (!_didIteratorError) {
+                            _context.next = 54;
+                            break;
+                        }
+
+                        throw _iteratorError;
+
+                    case 54:
+                        return _context.finish(51);
+
+                    case 55:
+                        return _context.finish(48);
+
+                    case 56:
+
+                        if (filesDownloaded === allFilesData.length) {
+                            console.log('gatsby-source-directus'.blue, 'success'.green, 'Downloaded all', filesDownloaded.toString().yellow, 'files from Directus.');
                         } else {
-                            console.log(`gatsby-source-directus`.blue, `warning`.yellow, `skipped`, (filesDownloaded - allFilesData.length).toString().yellow, 'files from downloading');
+                            console.log('gatsby-source-directus'.blue, 'warning'.yellow, 'skipped', (filesDownloaded - allFilesData.length).toString().yellow, 'files from downloading');
                         }
-                         */
 
                         console.log('gatsby-source-directus'.cyan, 'Fetching Directus tables data...');
 
                         // Fetch all the tables with data from Directus in a raw format
-                        _context.next = 14;
+                        _context.next = 60;
                         return fetcher.getAllTablesData();
 
-                    case 14:
+                    case 60:
                         allTablesData = _context.sent;
 
 
                         console.log('gatsby-source-directus'.blue, 'success'.green, 'Fetched', allTablesData.length.toString().yellow, 'tables from Directus.');
 
-                        _iteratorNormalCompletion = true;
-                        _didIteratorError = false;
-                        _iteratorError = undefined;
-                        _context.prev = 19;
-                        _iterator = allTablesData[Symbol.iterator]();
+                        _iteratorNormalCompletion2 = true;
+                        _didIteratorError2 = false;
+                        _iteratorError2 = undefined;
+                        _context.prev = 65;
+                        _iterator2 = allTablesData[Symbol.iterator]();
 
-                    case 21:
-                        if (_iteratorNormalCompletion = (_step = _iterator.next()).done) {
-                            _context.next = 68;
+                    case 67:
+                        if (_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done) {
+                            _context.next = 114;
                             break;
                         }
 
-                        tableData = _step.value;
+                        tableData = _step2.value;
                         tableNode = (0, _process.TableNode)(tableData);
-                        _context.next = 26;
+                        _context.next = 72;
                         return createNode(tableNode);
 
-                    case 26:
-                        _context.next = 28;
+                    case 72:
+                        _context.next = 74;
                         return fetcher.getAllItemsForTable(tableData.name);
 
-                    case 28:
+                    case 74:
                         tableItems = _context.sent;
 
                         console.log('gatsby-source-directus'.blue, 'success'.green, 'Fetched', tableItems.length.toString().cyan, 'items for ', tableData.name.cyan, ' table...');
@@ -172,24 +246,24 @@ exports.sourceNodes = function () {
                         ItemNode = (0, _process.createTableItemFactory)(name, allFiles);
 
                         if (!(tableItems && tableItems.length > 0)) {
-                            _context.next = 64;
+                            _context.next = 110;
                             break;
                         }
 
                         // Get all the items for the table above and create a gatsby node for it
-                        _iteratorNormalCompletion2 = true;
-                        _didIteratorError2 = false;
-                        _iteratorError2 = undefined;
-                        _context.prev = 37;
-                        _iterator2 = tableItems[Symbol.iterator]();
+                        _iteratorNormalCompletion3 = true;
+                        _didIteratorError3 = false;
+                        _iteratorError3 = undefined;
+                        _context.prev = 83;
+                        _iterator3 = tableItems[Symbol.iterator]();
 
-                    case 39:
-                        if (_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done) {
-                            _context.next = 47;
+                    case 85:
+                        if (_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done) {
+                            _context.next = 93;
                             break;
                         }
 
-                        tableItemData = _step2.value;
+                        tableItemData = _step3.value;
 
                         // Create a Table Item node based on the API response
                         tableItemNode = ItemNode(tableItemData, {
@@ -198,105 +272,105 @@ exports.sourceNodes = function () {
 
                         // Pass it to Gatsby to create a node
 
-                        _context.next = 44;
+                        _context.next = 90;
                         return createNode(tableItemNode);
 
-                    case 44:
+                    case 90:
+                        _iteratorNormalCompletion3 = true;
+                        _context.next = 85;
+                        break;
+
+                    case 93:
+                        _context.next = 99;
+                        break;
+
+                    case 95:
+                        _context.prev = 95;
+                        _context.t2 = _context['catch'](83);
+                        _didIteratorError3 = true;
+                        _iteratorError3 = _context.t2;
+
+                    case 99:
+                        _context.prev = 99;
+                        _context.prev = 100;
+
+                        if (!_iteratorNormalCompletion3 && _iterator3.return) {
+                            _iterator3.return();
+                        }
+
+                    case 102:
+                        _context.prev = 102;
+
+                        if (!_didIteratorError3) {
+                            _context.next = 105;
+                            break;
+                        }
+
+                        throw _iteratorError3;
+
+                    case 105:
+                        return _context.finish(102);
+
+                    case 106:
+                        return _context.finish(99);
+
+                    case 107:
+                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Directus' + name + ' node generated');
+                        _context.next = 111;
+                        break;
+
+                    case 110:
+                        console.log('gatsby-source-directus'.blue, 'warning'.yellow, tableData.name + ' table has no rows. Skipping...');
+
+                    case 111:
                         _iteratorNormalCompletion2 = true;
-                        _context.next = 39;
+                        _context.next = 67;
                         break;
 
-                    case 47:
-                        _context.next = 53;
+                    case 114:
+                        _context.next = 120;
                         break;
 
-                    case 49:
-                        _context.prev = 49;
-                        _context.t0 = _context['catch'](37);
+                    case 116:
+                        _context.prev = 116;
+                        _context.t3 = _context['catch'](65);
                         _didIteratorError2 = true;
-                        _iteratorError2 = _context.t0;
+                        _iteratorError2 = _context.t3;
 
-                    case 53:
-                        _context.prev = 53;
-                        _context.prev = 54;
+                    case 120:
+                        _context.prev = 120;
+                        _context.prev = 121;
 
                         if (!_iteratorNormalCompletion2 && _iterator2.return) {
                             _iterator2.return();
                         }
 
-                    case 56:
-                        _context.prev = 56;
+                    case 123:
+                        _context.prev = 123;
 
                         if (!_didIteratorError2) {
-                            _context.next = 59;
+                            _context.next = 126;
                             break;
                         }
 
                         throw _iteratorError2;
 
-                    case 59:
-                        return _context.finish(56);
+                    case 126:
+                        return _context.finish(123);
 
-                    case 60:
-                        return _context.finish(53);
+                    case 127:
+                        return _context.finish(120);
 
-                    case 61:
-                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Directus' + name + ' node generated');
-                        _context.next = 65;
-                        break;
-
-                    case 64:
-                        console.log('gatsby-source-directus'.blue, 'warning'.yellow, tableData.name + ' table has no rows. Skipping...');
-
-                    case 65:
-                        _iteratorNormalCompletion = true;
-                        _context.next = 21;
-                        break;
-
-                    case 68:
-                        _context.next = 74;
-                        break;
-
-                    case 70:
-                        _context.prev = 70;
-                        _context.t1 = _context['catch'](19);
-                        _didIteratorError = true;
-                        _iteratorError = _context.t1;
-
-                    case 74:
-                        _context.prev = 74;
-                        _context.prev = 75;
-
-                        if (!_iteratorNormalCompletion && _iterator.return) {
-                            _iterator.return();
-                        }
-
-                    case 77:
-                        _context.prev = 77;
-
-                        if (!_didIteratorError) {
-                            _context.next = 80;
-                            break;
-                        }
-
-                        throw _iteratorError;
-
-                    case 80:
-                        return _context.finish(77);
-
-                    case 81:
-                        return _context.finish(74);
-
-                    case 82:
+                    case 128:
 
                         console.log("AFTER");
 
-                    case 83:
+                    case 129:
                     case 'end':
                         return _context.stop();
                 }
             }
-        }, _callee, undefined, [[19, 70, 74, 82], [37, 49, 53, 61], [54,, 56, 60], [75,, 77, 81]]);
+        }, _callee, undefined, [[21, 44, 48, 56], [27, 33], [49,, 51, 55], [65, 116, 120, 128], [83, 95, 99, 107], [100,, 102, 106], [121,, 123, 127]]);
     }));
 
     return function (_x, _x2) {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -41,7 +41,7 @@ exports.sourceNodes = function () {
             fileRequestParams = _ref2.fileRequestParams,
             auth = _ref2.auth;
 
-        var createNode, fetcher, allFilesData, filesDownloaded, allFiles, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, fileData, fileNode, localFileNode, allTablesData, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, tableData, tableNode, tableItems, name, ItemNode, _iteratorNormalCompletion3, _didIteratorError3, _iteratorError3, _iterator3, _step3, tableItemData, tableItemNode;
+        var createNode, fetcher, allTablesData, _iteratorNormalCompletion, _didIteratorError, _iteratorError, _iterator, _step, tableData, tableNode, tableItems, name, ItemNode, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, tableItemData, tableItemNode;
 
         return regeneratorRuntime.wrap(function _callee$(_context) {
             while (1) {
@@ -77,162 +77,88 @@ exports.sourceNodes = function () {
                         // Initialize the Fetcher class with API key and URL
                         fetcher = new _fetch2.default(_apiKey, _url, _version, _requestParams, _fileRequestParams);
 
-
-                        console.log('gatsby-source-directus'.cyan, 'Fetching Directus files data...');
-
-                        _context.next = 14;
-                        return fetcher.getAllFiles();
-
-                    case 14:
-                        allFilesData = _context.sent;
-
-
-                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Fetched', allFilesData.length.toString().yellow, 'files from Directus.');
-                        console.log('gatsby-source-directus'.cyan, 'Downloading Directus files...');
-
-                        filesDownloaded = 0, allFiles = [];
-                        _iteratorNormalCompletion = true;
-                        _didIteratorError = false;
-                        _iteratorError = undefined;
-                        _context.prev = 21;
-                        _iterator = allFilesData[Symbol.iterator]();
-
-                    case 23:
-                        if (_iteratorNormalCompletion = (_step = _iterator.next()).done) {
-                            _context.next = 42;
-                            break;
+                        /*
+                        console.log(`gatsby-source-directus`.cyan, 'Fetching Directus files data...');
+                         const allFilesData = await fetcher.getAllFiles();
+                         console.log(`gatsby-source-directus`.blue, 'success'.green, `Fetched`, allFilesData.length.toString().yellow, `files from Directus.`);
+                        console.log(`gatsby-source-directus`.cyan, 'Downloading Directus files...');
+                         let filesDownloaded = 0,
+                            allFiles = [];
+                         for (let fileData of allFilesData) {
+                            const fileNode = FileNode(fileData);
+                            let localFileNode
+                             try {
+                                localFileNode = await createRemoteFileNode({
+                                url: encodeURI(`https:${fileNode.url}`),
+                                store,
+                                cache,
+                                createNode,
+                                createNodeId,
+                                auth: _auth,
+                                })
+                            } catch (e) {
+                                console.error(`\ngatsby-source-directus`.blue, 'error'.red, `gatsby-source-directus: An error occurred while downloading the files.`, e);
+                            }
+                             if (localFileNode) {
+                                filesDownloaded++;
+                                fileNode.localFile___NODE = localFileNode.id;
+                                 // When `gatsby-source-filesystem` creates the file nodes, all reference
+                                // to the original data source is wiped out. This object links the
+                                // directus reference (that's used by other objects to reference files)
+                                // to the gatsby reference (that's accessible in GraphQL queries). Then,
+                                // when each table row is created (in ./process.js), if a file is on a row
+                                // we find it in this array and put the Gatsby URL on the directus node.
+                                //
+                                // This is a hacky solution, but it does the trick for very basic raw file capture
+                                // TODO see if we can implement gatsby-transformer-sharp style queries
+                                allFiles.push({
+                                    directus: fileNode,
+                                    gatsby: localFileNode
+                                });
+                            }
+                             await createNode(fileNode);
                         }
-
-                        fileData = _step.value;
-                        fileNode = (0, _process.FileNode)(fileData);
-                        localFileNode = void 0;
-                        _context.prev = 27;
-                        _context.next = 30;
-                        return (0, _gatsbySourceFilesystem.createRemoteFileNode)({
-                            url: encodeURI('https:' + fileNode.url),
-                            store: store,
-                            cache: cache,
-                            createNode: createNode,
-                            createNodeId: createNodeId,
-                            auth: _auth
-                        });
-
-                    case 30:
-                        localFileNode = _context.sent;
-                        _context.next = 36;
-                        break;
-
-                    case 33:
-                        _context.prev = 33;
-                        _context.t0 = _context['catch'](27);
-
-                        console.error('\ngatsby-source-directus'.blue, 'error'.red, 'gatsby-source-directus: An error occurred while downloading the files.', _context.t0);
-
-                    case 36:
-
-                        if (localFileNode) {
-                            filesDownloaded++;
-                            fileNode.localFile___NODE = localFileNode.id;
-
-                            // When `gatsby-source-filesystem` creates the file nodes, all reference
-                            // to the original data source is wiped out. This object links the
-                            // directus reference (that's used by other objects to reference files)
-                            // to the gatsby reference (that's accessible in GraphQL queries). Then,
-                            // when each table row is created (in ./process.js), if a file is on a row
-                            // we find it in this array and put the Gatsby URL on the directus node.
-                            //
-                            // This is a hacky solution, but it does the trick for very basic raw file capture
-                            // TODO see if we can implement gatsby-transformer-sharp style queries
-                            allFiles.push({
-                                directus: fileNode,
-                                gatsby: localFileNode
-                            });
-                        }
-
-                        _context.next = 39;
-                        return createNode(fileNode);
-
-                    case 39:
-                        _iteratorNormalCompletion = true;
-                        _context.next = 23;
-                        break;
-
-                    case 42:
-                        _context.next = 48;
-                        break;
-
-                    case 44:
-                        _context.prev = 44;
-                        _context.t1 = _context['catch'](21);
-                        _didIteratorError = true;
-                        _iteratorError = _context.t1;
-
-                    case 48:
-                        _context.prev = 48;
-                        _context.prev = 49;
-
-                        if (!_iteratorNormalCompletion && _iterator.return) {
-                            _iterator.return();
-                        }
-
-                    case 51:
-                        _context.prev = 51;
-
-                        if (!_didIteratorError) {
-                            _context.next = 54;
-                            break;
-                        }
-
-                        throw _iteratorError;
-
-                    case 54:
-                        return _context.finish(51);
-
-                    case 55:
-                        return _context.finish(48);
-
-                    case 56:
-
-                        if (filesDownloaded === allFilesData.length) {
-                            console.log('gatsby-source-directus'.blue, 'success'.green, 'Downloaded all', filesDownloaded.toString().yellow, 'files from Directus.');
+                         if (filesDownloaded === allFilesData.length) {
+                            console.log(`gatsby-source-directus`.blue, 'success'.green, `Downloaded all`, filesDownloaded.toString().yellow, `files from Directus.`);
                         } else {
-                            console.log('gatsby-source-directus'.blue, 'warning'.yellow, 'skipped', (filesDownloaded - allFilesData.length).toString().yellow, 'files from downloading');
+                            console.log(`gatsby-source-directus`.blue, `warning`.yellow, `skipped`, (filesDownloaded - allFilesData.length).toString().yellow, 'files from downloading');
                         }
+                         */
 
                         console.log('gatsby-source-directus'.cyan, 'Fetching Directus tables data...');
 
                         // Fetch all the tables with data from Directus in a raw format
-                        _context.next = 60;
+                        _context.next = 14;
                         return fetcher.getAllTablesData();
 
-                    case 60:
+                    case 14:
                         allTablesData = _context.sent;
 
 
                         console.log('gatsby-source-directus'.blue, 'success'.green, 'Fetched', allTablesData.length.toString().yellow, 'tables from Directus.');
 
-                        _iteratorNormalCompletion2 = true;
-                        _didIteratorError2 = false;
-                        _iteratorError2 = undefined;
-                        _context.prev = 65;
-                        _iterator2 = allTablesData[Symbol.iterator]();
+                        _iteratorNormalCompletion = true;
+                        _didIteratorError = false;
+                        _iteratorError = undefined;
+                        _context.prev = 19;
+                        _iterator = allTablesData[Symbol.iterator]();
 
-                    case 67:
-                        if (_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done) {
-                            _context.next = 114;
+                    case 21:
+                        if (_iteratorNormalCompletion = (_step = _iterator.next()).done) {
+                            _context.next = 68;
                             break;
                         }
 
-                        tableData = _step2.value;
+                        tableData = _step.value;
                         tableNode = (0, _process.TableNode)(tableData);
-                        _context.next = 72;
+                        _context.next = 26;
                         return createNode(tableNode);
 
-                    case 72:
-                        _context.next = 74;
+                    case 26:
+                        _context.next = 28;
                         return fetcher.getAllItemsForTable(tableData.name);
 
-                    case 74:
+                    case 28:
                         tableItems = _context.sent;
 
                         console.log('gatsby-source-directus'.blue, 'success'.green, 'Fetched', tableItems.length.toString().cyan, 'items for ', tableData.name.cyan, ' table...');
@@ -246,24 +172,24 @@ exports.sourceNodes = function () {
                         ItemNode = (0, _process.createTableItemFactory)(name, allFiles);
 
                         if (!(tableItems && tableItems.length > 0)) {
-                            _context.next = 110;
+                            _context.next = 64;
                             break;
                         }
 
                         // Get all the items for the table above and create a gatsby node for it
-                        _iteratorNormalCompletion3 = true;
-                        _didIteratorError3 = false;
-                        _iteratorError3 = undefined;
-                        _context.prev = 83;
-                        _iterator3 = tableItems[Symbol.iterator]();
+                        _iteratorNormalCompletion2 = true;
+                        _didIteratorError2 = false;
+                        _iteratorError2 = undefined;
+                        _context.prev = 37;
+                        _iterator2 = tableItems[Symbol.iterator]();
 
-                    case 85:
-                        if (_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done) {
-                            _context.next = 93;
+                    case 39:
+                        if (_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done) {
+                            _context.next = 47;
                             break;
                         }
 
-                        tableItemData = _step3.value;
+                        tableItemData = _step2.value;
 
                         // Create a Table Item node based on the API response
                         tableItemNode = ItemNode(tableItemData, {
@@ -272,105 +198,105 @@ exports.sourceNodes = function () {
 
                         // Pass it to Gatsby to create a node
 
-                        _context.next = 90;
+                        _context.next = 44;
                         return createNode(tableItemNode);
 
-                    case 90:
-                        _iteratorNormalCompletion3 = true;
-                        _context.next = 85;
-                        break;
-
-                    case 93:
-                        _context.next = 99;
-                        break;
-
-                    case 95:
-                        _context.prev = 95;
-                        _context.t2 = _context['catch'](83);
-                        _didIteratorError3 = true;
-                        _iteratorError3 = _context.t2;
-
-                    case 99:
-                        _context.prev = 99;
-                        _context.prev = 100;
-
-                        if (!_iteratorNormalCompletion3 && _iterator3.return) {
-                            _iterator3.return();
-                        }
-
-                    case 102:
-                        _context.prev = 102;
-
-                        if (!_didIteratorError3) {
-                            _context.next = 105;
-                            break;
-                        }
-
-                        throw _iteratorError3;
-
-                    case 105:
-                        return _context.finish(102);
-
-                    case 106:
-                        return _context.finish(99);
-
-                    case 107:
-                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Directus' + name + ' node generated');
-                        _context.next = 111;
-                        break;
-
-                    case 110:
-                        console.log('gatsby-source-directus'.blue, 'warning'.yellow, tableData.name + ' table has no rows. Skipping...');
-
-                    case 111:
+                    case 44:
                         _iteratorNormalCompletion2 = true;
-                        _context.next = 67;
+                        _context.next = 39;
                         break;
 
-                    case 114:
-                        _context.next = 120;
+                    case 47:
+                        _context.next = 53;
                         break;
 
-                    case 116:
-                        _context.prev = 116;
-                        _context.t3 = _context['catch'](65);
+                    case 49:
+                        _context.prev = 49;
+                        _context.t0 = _context['catch'](37);
                         _didIteratorError2 = true;
-                        _iteratorError2 = _context.t3;
+                        _iteratorError2 = _context.t0;
 
-                    case 120:
-                        _context.prev = 120;
-                        _context.prev = 121;
+                    case 53:
+                        _context.prev = 53;
+                        _context.prev = 54;
 
                         if (!_iteratorNormalCompletion2 && _iterator2.return) {
                             _iterator2.return();
                         }
 
-                    case 123:
-                        _context.prev = 123;
+                    case 56:
+                        _context.prev = 56;
 
                         if (!_didIteratorError2) {
-                            _context.next = 126;
+                            _context.next = 59;
                             break;
                         }
 
                         throw _iteratorError2;
 
-                    case 126:
-                        return _context.finish(123);
+                    case 59:
+                        return _context.finish(56);
 
-                    case 127:
-                        return _context.finish(120);
+                    case 60:
+                        return _context.finish(53);
 
-                    case 128:
+                    case 61:
+                        console.log('gatsby-source-directus'.blue, 'success'.green, 'Directus' + name + ' node generated');
+                        _context.next = 65;
+                        break;
+
+                    case 64:
+                        console.log('gatsby-source-directus'.blue, 'warning'.yellow, tableData.name + ' table has no rows. Skipping...');
+
+                    case 65:
+                        _iteratorNormalCompletion = true;
+                        _context.next = 21;
+                        break;
+
+                    case 68:
+                        _context.next = 74;
+                        break;
+
+                    case 70:
+                        _context.prev = 70;
+                        _context.t1 = _context['catch'](19);
+                        _didIteratorError = true;
+                        _iteratorError = _context.t1;
+
+                    case 74:
+                        _context.prev = 74;
+                        _context.prev = 75;
+
+                        if (!_iteratorNormalCompletion && _iterator.return) {
+                            _iterator.return();
+                        }
+
+                    case 77:
+                        _context.prev = 77;
+
+                        if (!_didIteratorError) {
+                            _context.next = 80;
+                            break;
+                        }
+
+                        throw _iteratorError;
+
+                    case 80:
+                        return _context.finish(77);
+
+                    case 81:
+                        return _context.finish(74);
+
+                    case 82:
 
                         console.log("AFTER");
 
-                    case 129:
+                    case 83:
                     case 'end':
                         return _context.stop();
                 }
             }
-        }, _callee, undefined, [[21, 44, 48, 56], [27, 33], [49,, 51, 55], [65, 116, 120, 128], [83, 95, 99, 107], [100,, 102, 106], [121,, 123, 127]]);
+        }, _callee, undefined, [[19, 70, 74, 82], [37, 49, 53, 61], [54,, 56, 60], [75,, 77, 81]]);
     }));
 
     return function (_x, _x2) {

--- a/process.js
+++ b/process.js
@@ -1,0 +1,104 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.getNodeTypeNameForTable = exports.createTableItemFactory = exports.FileNode = exports.TableNode = undefined;
+
+var _gatsbyNodeHelpers = require('gatsby-node-helpers');
+
+var _gatsbyNodeHelpers2 = _interopRequireDefault(_gatsbyNodeHelpers);
+
+var _pluralize = require('pluralize');
+
+var _pluralize2 = _interopRequireDefault(_pluralize);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var _createNodeHelpers = (0, _gatsbyNodeHelpers2.default)({
+    typePrefix: 'Directus'
+}),
+    createNodeFactory = _createNodeHelpers.createNodeFactory;
+
+var TABLE_NODE_TYPE = 'Table';
+var FILE_NODE_TYPE = 'File';
+
+/*
+ *  Removes unnecessary fields from the response
+ */
+var sanitizeDirectusFields = function sanitizeDirectusFields(node) {
+    delete node.schema;
+    delete node.sort_column;
+    delete node.status_column;
+    delete node.status_mapping;
+    delete node.user_create_column;
+    delete node.user_update_column;
+    delete node.date_create_column;
+    delete node.date_update_column;
+    delete node.comment;
+    delete node.footer;
+    delete node.column_groupings;
+    delete node.preview_url;
+    delete node.display_template;
+    delete node.filter_column_blacklist;
+    delete node.preferences;
+    delete node.columns;
+    delete node.storage_adapter;
+    delete node.thumbnail_url;
+    delete node.old_thumbnail_url;
+    return node;
+};
+
+var TableNode = exports.TableNode = createNodeFactory(TABLE_NODE_TYPE, function (node) {
+    return sanitizeDirectusFields(node);
+});
+
+var FileNode = exports.FileNode = createNodeFactory(FILE_NODE_TYPE, function (node) {
+    return sanitizeDirectusFields(node);
+});
+
+// A little wrapper for the createItemFactory to not have to import the gatsby-node-helpers in the main file
+var createTableItemFactory = exports.createTableItemFactory = function createTableItemFactory(name, allFiles) {
+    return createNodeFactory(name, function (node) {
+        node = sanitizeDirectusFields(node);
+
+        // For each property on each row, check if it's a "file" property. If it is, find the file object
+        // from `gatsby-source-filesystem` and add the URL to the property's object
+        Object.keys(node).forEach(function (key) {
+            if (node[key] && node[key].meta && node[key].meta.type === 'item') {
+                var _name = node[key].data && node[key].data.name;
+                var file = allFiles.find(function (file) {
+                    return file.directus.name === _name;
+                });
+                if (file) {
+                    node[key].file___NODE = file.gatsby.id;
+                }
+            }
+        });
+
+        return node;
+    });
+};
+
+// Transforms the table name into a Gatsby Node Type name
+// All this does, is making the first letter uppercase and singularizing it if possible.
+// Also, it checks if there's an exception to this name to use instead
+var getNodeTypeNameForTable = exports.getNodeTypeNameForTable = function getNodeTypeNameForTable(name, exceptions) {
+
+    // If there's an exception for this name, use it instead
+    // Otherwise, generate a new one
+    if (exceptions !== undefined && Object.keys(exceptions).length > 0 && exceptions[name] !== undefined) {
+        return exceptions[name];
+    }
+
+    // If the name is plural, use the Pluralize plugin to try make it singular
+    // This is to conform to the Gatsby convention of using singular names in their node types
+    if (_pluralize2.default.isPlural(name)) {
+        name = _pluralize2.default.singular(name);
+    }
+
+    // Make the first letter upperace as per Gatsby's convention
+    name = name.charAt(0).toUpperCase() + name.slice(1);
+
+    return name;
+};

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -12,7 +12,7 @@ let _requestParams = {
 let _fileRequestParams = {}
 let _auth = {}
 
-exports.sourceNodes = async ({ boundActionCreators, getNode, store, cache, createNodeId }, {
+exports.sourceNodes = async ({ actions, getNode, store, cache, createNodeId }, {
     url,
     protocol,
     apiKey,
@@ -22,7 +22,7 @@ exports.sourceNodes = async ({ boundActionCreators, getNode, store, cache, creat
     fileRequestParams,
     auth,
 }) => {
-    const { createNode } = boundActionCreators;
+    const { createNode } = actions;
 
     protocol = protocol !== undefined && protocol !== '' ? protocol : 'http';
     protocol = protocol + "://";
@@ -67,7 +67,7 @@ exports.sourceNodes = async ({ boundActionCreators, getNode, store, cache, creat
 
         try {
             localFileNode = await createRemoteFileNode({
-            url: protocol + url + fileNode.url,
+            url: encodeURI(`https:${fileNode.url}`),
             store,
             cache,
             createNode,

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -51,6 +51,7 @@ exports.sourceNodes = async ({ actions, getNode, store, cache, createNodeId }, {
     // Initialize the Fetcher class with API key and URL
     const fetcher = new Fetcher(_apiKey, _url, _version, _requestParams, _fileRequestParams);
 
+    /*
     console.log(`gatsby-source-directus`.cyan, 'Fetching Directus files data...');
 
     const allFilesData = await fetcher.getAllFiles();
@@ -105,6 +106,8 @@ exports.sourceNodes = async ({ actions, getNode, store, cache, createNodeId }, {
     } else {
         console.log(`gatsby-source-directus`.blue, `warning`.yellow, `skipped`, (filesDownloaded - allFilesData.length).toString().yellow, 'files from downloading');
     }
+
+    */
 
     console.log(`gatsby-source-directus`.cyan, 'Fetching Directus tables data...');
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -51,7 +51,6 @@ exports.sourceNodes = async ({ actions, getNode, store, cache, createNodeId }, {
     // Initialize the Fetcher class with API key and URL
     const fetcher = new Fetcher(_apiKey, _url, _version, _requestParams, _fileRequestParams);
 
-    /*
     console.log(`gatsby-source-directus`.cyan, 'Fetching Directus files data...');
 
     const allFilesData = await fetcher.getAllFiles();
@@ -106,8 +105,6 @@ exports.sourceNodes = async ({ actions, getNode, store, cache, createNodeId }, {
     } else {
         console.log(`gatsby-source-directus`.blue, `warning`.yellow, `skipped`, (filesDownloaded - allFilesData.length).toString().yellow, 'files from downloading');
     }
-
-    */
 
     console.log(`gatsby-source-directus`.cyan, 'Fetching Directus tables data...');
 


### PR DESCRIPTION
* Renames `boundActionCreators` to `actions` for Gatsby v3 compatibility

https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#removal-of-boundactioncreators

@iKonrad 